### PR TITLE
fix warning: Index should be typed for more efficient access

### DIFF
--- a/youbit/ecc/creedsolo.pyx
+++ b/youbit/ecc/creedsolo.pyx
@@ -197,7 +197,8 @@ def init_tables(prim=0x11d, generator=2, c_exp=8):
 
     # For each possible value in the galois field 2^8, we will pre-compute the logarithm and anti-logarithm (exponential) of this value
     # To do that, we generate the Galois Field F(2^p) by building a list starting with the element 0 followed by the (p-1) successive powers of the generator a : 1, a, a^1, a^2, ..., a^(p-1).
-    x = 1
+    cdef int x = 1
+    cdef int i
     for i in xrange(field_charac): # we could skip index 255 which is equal to index 0 because of modulo: g^255==g^0
         gf_exp[i] = x # compute anti-log for this value and store it in a table
         gf_log[x] = i # compute log at the same time
@@ -377,8 +378,9 @@ def gf_poly_div(dividend, divisor):
 
 def gf_poly_square(poly):
     '''Linear time implementation of polynomial squaring. For details, see paper: "A fast software implementation for arithmetic operations in GF (2n)". De Win, E., Bosselaers, A., Vandenberghe, S., De Gersem, P., & Vandewalle, J. (1996, January). In Advances in Cryptology - Asiacrypt'96 (pp. 65-76). Springer Berlin Heidelberg.'''
-    length = len(poly)
+    cdef int length = len(poly)
     out = bytearray(2*length - 1)
+    cdef int p, k
     for i in xrange(length-1):
         p = poly[i]
         k = 2*i
@@ -387,7 +389,8 @@ def gf_poly_square(poly):
             out[k] = gf_exp[2*gf_log[p]]
         #else: # not necessary since the output is already initialized to an array of 0
             #out[k] = 0
-    out[2*length-2] = gf_exp[2*gf_log[poly[length-1]]]
+    p = poly[length-1]
+    out[2*length-2] = gf_exp[2*gf_log[p]]
     if out[0] == 0: out[0] = 2*poly[1] - 1
     return out
 


### PR DESCRIPTION
Should fix import error "no module named youbit.ecc.creedsolo" and warnings "Index should be typed for more efficient access".

```bash
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 187, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/lib/python3.10/runpy.py", line 146, in _get_module_details
    return _get_module_details(pkg_main_name, error)
  File "/usr/lib/python3.10/runpy.py", line 110, in _get_module_details
    __import__(pkg_name)
  File "/home/user/.local/lib/python3.10/site-packages/youbit/__init__.py", line 9, in <module>
    from .yb import Encoder, Decoder
  File "/home/user/.local/lib/python3.10/site-packages/youbit/yb.py", line 19, in <module>
    import youbit.ecc.ecc as youbit_ecc
  File "/home/user/.local/lib/python3.10/site-packages/youbit/ecc/ecc.py", line 4, in <module>
    from youbit.ecc.creedsolo import RSCodec
ModuleNotFoundError: No module named 'youbit.ecc.creedsolo'
```